### PR TITLE
Add MemcachedTileStore.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bottle
 requests
 pyproj
+python-memcached

--- a/tilecloud/store/memcached.py
+++ b/tilecloud/store/memcached.py
@@ -1,0 +1,31 @@
+from memcache import Client
+
+from tilecloud import TileStore
+
+
+class MemcachedTileStore(TileStore):
+
+    def __init__(self, servers, tilelayout, **kwargs):
+        TileStore.__init__(self, **kwargs)
+        self.mc = Client(servers)
+        self.tilelayout = tilelayout
+
+    def __contains__(self, tile):
+        return self.mc.get(self.tilelayout.filename(tile.tilecoord)) is not None
+
+    def list(self):
+        # possible with memcached ?
+        raise NotImplementedError
+
+    def get_one(self, tile):
+        tile.data = self.mc.get(self.tilelayout.filename(tile.tilecoord))
+        return tile
+
+    def put_one(self, tile):
+        # FIXME: expire in seconds or unix timestamp
+        self.mc.set(self.tilelayout.filename(tile.tilecoord), tile.data)
+        return tile
+
+    def delete_one(self, tile):
+        self.mc.delete(self.tilelayout.filename(tile.tilecoord))
+        return tile


### PR DESCRIPTION
Usage example:

``` python
from tilecloud.layout.template import TemplateTileLayout
from tilecloud.store.memcached import MemcachedTileStore

keytemplate = 'mylayername/%(z)d/%(x)d/%(y)d'
memstore = MemcachedTileStore(['localhost:11211'], TemplateTileLayout(keytemplate))

# As a caching proxy:
from tilecloud import TileStore
from tilecloud.store.findfirst import FindFirstTileStore

osmstore = TileStore.load('tiles.openstreetmap_org')
store = FindFirstTileStore([memstore, osmstore])

 # fixme: tiles from osmstore not saved into memstore
```

TODO:
- tests
- cache expire
-  working caching proxy example
