### PR TITLE
Add missing return tile on put_one in SQS store

### DIFF
--- a/tilecloud/store/sqs.py
+++ b/tilecloud/store/sqs.py
@@ -70,3 +70,4 @@ class SQSTileStore(TileStore):
             tile.sqs_message = sqs_message
         except SQSError as e:
             tile.error = e
+        return tile


### PR DESCRIPTION
Without that in 'tilecloud.consume(iterator, n)' will not respect the n value.
