### PR TITLE
Test to figure out if resolutions are long instead of integer

### DIFF
--- a/tilecloud/grid/free.py
+++ b/tilecloud/grid/free.py
@@ -8,7 +8,7 @@ class FreeTileGrid(TileGrid):
     def __init__(self, resolutions, max_extent=None, tile_size=None, scale=1, flip_y=False):
         TileGrid.__init__(self, max_extent=max_extent, tile_size=tile_size, flip_y=flip_y)
         assert list(resolutions) == sorted(resolutions, reverse=True)
-        assert all(isinstance(r, int) for r in resolutions)
+        assert all(isinstance(r, int) or isinstance(r, long) for r in resolutions)
         self.resolutions = resolutions
         self.scale = 1 if scale is 1 else float(scale)
         self.parent_zs = []


### PR DESCRIPTION
TileCloud-Chain applies a scale factor so that resolutions submitted to TileCloud are actually integers.

Depending on the resolution set (for instance when generating OSM tiles), the final resolutions may become really big and use type "long" instead of "int", making the int assertion fail.
