### PR TITLE
Don't tc-copy missing tiles?

### DIFF
--- a/tilecloud/store/url.py
+++ b/tilecloud/store/url.py
@@ -26,6 +26,8 @@ class URLTileStore(TileStore):
         logger.debug('GET %s' % (url,))
         try:
             response = self.session.get(url)
+            if response.status_code == 404:
+                return None
             tile.content_encoding = response.headers.get('Content-Encoding')
             tile.content_type = response.headers.get('Content-Type')
             tile.data = response.content


### PR DESCRIPTION
I have used `tc-copy` to import a local set of tile files (from `http://localhost/%(z)d/...`) into a mbtiles file.

To my surprise missing tiles (http status 404) got imported into the mbtiles file, with the HTML 404 page content. I had to manually purge these by doing `"delete from tiles where tile_data like '<!DOCTYPE%';"`
