### PR TITLE
Use passed-in on_empty function in SQSTileStore

### DIFF
--- a/tilecloud/store/sqs.py
+++ b/tilecloud/store/sqs.py
@@ -23,7 +23,7 @@ class SQSTileStore(TileStore):
     def __init__(self, queue, on_empty=maybe_stop, **kwargs):
         TileStore.__init__(self, **kwargs)
         self.queue = queue
-        self.on_empty = maybe_stop
+        self.on_empty = on_empty
 
     def __contains__(self, tile):
         return False


### PR DESCRIPTION
`SQSTileStore` receives as an argument an `on_empty` function, but always sets its `on_empty` callback to `maybe_stop`.

This PR makes it use the received function (which defaults to `maybe_stop`)