### PR TITLE
Save tile metadata to SQS

### DIFF
--- a/tilecloud/__init__.py
+++ b/tilecloud/__init__.py
@@ -298,6 +298,9 @@ class Tile(object):
         :param data: Data
         :type data: string or ``None``
 
+        :param layer: Layer
+        :type layer: string or ``None``
+
         :param kwargs: Extra attributes
 
         """
@@ -306,6 +309,7 @@ class Tile(object):
         self.content_type = content_type
         self.data = data
         self.error = None
+        self.metadata = kwargs
         for key, value in iteritems(kwargs):
             setattr(self, key, value)
 

--- a/tilecloud/lib/sqs.py
+++ b/tilecloud/lib/sqs.py
@@ -18,6 +18,10 @@ class SQSDeque(object):
         sqs_message['z'] = tile.tilecoord.z
         sqs_message['x'] = tile.tilecoord.x
         sqs_message['y'] = tile.tilecoord.y
+        sqs_message['metadata'] = tile.metadata
+        if 'sqs_message' in sqs_message['metadata']:
+            del sqs_message['metadata']['sqs_message']
+
         self.queue.write(sqs_message)
 
     def popleft(self):
@@ -27,4 +31,5 @@ class SQSDeque(object):
         z = sqs_message.get('z')
         x = sqs_message.get('x')
         y = sqs_message.get('y')
-        return Tile(TileCoord(z, x, y), sqs_message=sqs_message)
+        metadata = sqs_message.get('metadata', {})
+        return Tile(TileCoord(z, x, y), sqs_message=sqs_message, **metadata)

--- a/tilecloud/store/metatile.py
+++ b/tilecloud/store/metatile.py
@@ -32,4 +32,4 @@ class MetaTileSplitterTileStore(TileStore):
                 image = metaimage.crop((x, y, x + self.tile_size, y + self.tile_size))
                 string_io = StringIO()
                 image.save(string_io, FORMAT_BY_CONTENT_TYPE[self.format])
-                yield Tile(tilecoord, data=string_io.getvalue(), content_type=self.format)
+                yield Tile(tilecoord, data=string_io.getvalue(), content_type=self.format, **metatile.metadata)

--- a/tilecloud/store/sqs.py
+++ b/tilecloud/store/sqs.py
@@ -46,8 +46,9 @@ class SQSTileStore(TileStore):
                     x = sqs_message.get('x')
                     y = sqs_message.get('y')
                     n = sqs_message.get('n')
+                    metadata = sqs_message.get('metadata', {})
                     # FIXME deserialize other attributes
-                    tile = Tile(TileCoord(z, x, y, n), sqs_message=sqs_message)
+                    tile = Tile(TileCoord(z, x, y, n), sqs_message=sqs_message, **metadata)
                     yield tile
             except SQSDecodeError as e:
                 logger.warning(str(e))
@@ -66,6 +67,10 @@ class SQSTileStore(TileStore):
         sqs_message['x'] = tile.tilecoord.x
         sqs_message['y'] = tile.tilecoord.y
         sqs_message['n'] = tile.tilecoord.n
+        sqs_message['metadata'] = tile.metadata
+        if 'sqs_message' in sqs_message['metadata']:
+            del sqs_message['metadata']['sqs_message']
+
         # FIXME serialize other attributes
         try:
             self.queue.write(sqs_message)


### PR DESCRIPTION
This PR lets the SQS store and the Metatile splitter store handle additional tile metadata (storing and restoring it for the former, and propagating to the subtiles for the latter)