### PR TITLE
wmts filename method expect a list of metadata as parameter

### DIFF
--- a/tilecloud/store/s3.py
+++ b/tilecloud/store/s3.py
@@ -35,7 +35,7 @@ class S3TileStore(TileStore):
 
     def delete_one(self, tile):
         try:
-            key_name = self.tilelayout.filename(tile.tilecoord)
+            key_name = self.tilelayout.filename(tile.tilecoord, tile.metadata)
             if not self.dry_run:
                 self.client.delete_object(Bucket=self.bucket, Key=key_name)
         except botocore.exceptions.ClientError as exc:
@@ -43,7 +43,7 @@ class S3TileStore(TileStore):
         return tile
 
     def get_one(self, tile):
-        key_name = self.tilelayout.filename(tile.tilecoord)
+        key_name = self.tilelayout.filename(tile.tilecoord, tile.metadata)
         try:
             response = self.client.get_object(Bucket=self.bucket, Key=key_name)
             tile.data = response['Body'].read()


### PR DESCRIPTION
fix

Traceback (most recent call last):
  File "/usr/local/bin/generate_tiles", line 11, in <module>
    load_entry_point('tilecloud-chain==1.4.0', 'console_scripts', 'generate_tiles')()
  File "/usr/local/lib/python3.6/site-packages/tilecloud_chain/generate.py", line 499, in main
    generate.gene(gene.layers[options.layer])
  File "/usr/local/lib/python3.6/site-packages/tilecloud_chain/generate.py", line 55, in gene
    self.generate_consume()
  File "/usr/local/lib/python3.6/site-packages/tilecloud_chain/generate.py", line 280, in generate_consume
    self._gene.consume()
  File "/usr/local/lib/python3.6/site-packages/tilecloud_chain/__init__.py", line 1046, in consume
    consume(self.tilestream, test)
  File "/usr/local/lib/python3.6/site-packages/tilecloud/__init__.py", line 25, in consume
    collections.deque(iterator, maxlen=0)
  File "/usr/local/lib/python3.6/site-packages/tilecloud/store/s3.py", line 70, in put_one
    key_name = self.tilelayout.filename(tile.tilecoord)
  File "/usr/local/lib/python3.6/site-packages/tilecloud/layout/wmts.py", line 42, in filename
    query.append((name, metadata['dimension_' + name]))
KeyError: 'dimension_DATE'
