### PR TITLE
Reduce memory usage for S3.

### DIFF
--- a/tilecloud/store/s3.py
+++ b/tilecloud/store/s3.py
@@ -97,6 +97,5 @@ def _get_status(s3_client_exception):
 
 def get_client(s3_host):
     config = botocore.config.Config(connect_timeout=CLIENT_TIMEOUT, read_timeout=CLIENT_TIMEOUT)
-    session = boto3.session.Session()
-    return session.client('s3', endpoint_url=('https://%s/' % s3_host) if s3_host is not None else None,
-                          config=config)
+    return boto3.client('s3', endpoint_url=('https://%s/' % s3_host) if s3_host is not None else None,
+                        config=config)


### PR DESCRIPTION
The problem was that for each S3TileStore we were instanciating a different
boto3.session.Session. This guy contains a cache for the whole AWS API
specification, including the doc. Roughly 3MB wasted by instance.

By using the boto3.client helper function, we use a global session, shared
between the connections. In tilecloud-chain, we use boto3.resource to
get the SQS queue and this guy uses the global session as well.