### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM osgeo/gdal:3.2.0
 
 RUN apt update
 RUN apt install --yes python3-wheel python3-setuptools python3-pip libpq-dev
-RUN python3 -m pip install Cython
+RUN python3 -m pip install --no-cache-dir Cython
 
 WORKDIR /app
 
 COPY requirements-dev.txt ./
-RUN python3 -m pip install --requirement=requirements-dev.txt
+RUN python3 -m pip install --no-cache-dir --requirement=requirements-dev.txt
 
 COPY requirements.txt ./
-RUN python3 -m pip install --requirement=requirements.txt
+RUN python3 -m pip install --no-cache-dir --requirement=requirements.txt


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>