### PR TITLE
Redis improvement:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## Display this help message
 		awk 'BEGIN {FS = ":.*?## "}; {printf "	%-20s%s\n", $$1, $$2}'
 
 .PHONY: all
-all: test prospector docs
+all: tests prospector docs
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Faster claim pendings
Add some debugging logs
Be able to configure pending_count

Currently, every second, he gets 10 pendings tiles, but he always gets the dame then he didn't do anything